### PR TITLE
get the blank page when visit some url

### DIFF
--- a/libadblockplus-android-webview/src/org/adblockplus/libadblockplus/android/webview/AdblockWebView.java
+++ b/libadblockplus-android-webview/src/org/adblockplus/libadblockplus/android/webview/AdblockWebView.java
@@ -275,6 +275,20 @@ public class AdblockWebView extends WebView
     @Override
     public void onReceivedTitle(WebView view, String title)
     {
+    
+      // addDomListener is changed to 'false' in `setAddDomListener` invoked from injected JS
+      if (getAddDomListener() && loadError == null && injectJs != null)
+      {
+        d("Injecting script");
+        runScript(injectJs);
+
+        if (allowDraw && loading)
+        {
+          startPreventDrawing();
+        }
+      }
+      
+      
       if (extWebChromeClient != null)
       {
         extWebChromeClient.onReceivedTitle(view, title);
@@ -557,17 +571,7 @@ public class AdblockWebView extends WebView
     {
       d("Loading progress=" + newProgress + "%");
 
-      // addDomListener is changed to 'false' in `setAddDomListener` invoked from injected JS
-      if (getAddDomListener() && loadError == null && injectJs != null)
-      {
-        d("Injecting script");
-        runScript(injectJs);
-
-        if (allowDraw && loading)
-        {
-          startPreventDrawing();
-        }
-      }
+      
 
       if (extWebChromeClient != null)
       {


### PR DESCRIPTION
the bug is that get the blank page when visit the url "https://m.baidu.com/ssid=23816c696a756e6a69656f6e65fc18/s?word=%E6%96%B9%E7%89%B9%E6%AC%A2%E4%B9%90%E4%B8%96%E7%95%8C&rq=%E6%96%B9%E7%89%B9&sa=fqrs_1&dsid=0&rqid=11734469654775658318”  and click the "方特欢乐世界_百度百科” on the page.